### PR TITLE
Add health endpoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: ruby
 rvm:
   - 2.2.3
 before_install: gem install bundler -v 1.10.6
+services:
+  - redis-server

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ Sidekiq.configure_client do |config|
 end
 ```
 
+To enable the `GET /health/sidekiq` health endpoint add the following to your `lib/routes.rb`
+
+```ruby
+mount Pliny::Sidekiq::Endpoints::Health
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake false` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Sidekiq middlewares for making life nicer when using Pliny
 
  - Passes `request_id`s to and between jobs.
  - logfmts when jobs are enqueued and being processed.
+ - Health endpoints for tracking queue latency and depth.
 
 ## Installation
 

--- a/lib/pliny/sidekiq.rb
+++ b/lib/pliny/sidekiq.rb
@@ -1,4 +1,5 @@
 require "pliny/sidekiq/version"
+require "pliny/sidekiq/endpoints/health"
 require "pliny/sidekiq/middleware/client/log"
 require "pliny/sidekiq/middleware/client/request_id"
 require "pliny/sidekiq/middleware/server/log"

--- a/lib/pliny/sidekiq/endpoints/health.rb
+++ b/lib/pliny/sidekiq/endpoints/health.rb
@@ -1,0 +1,47 @@
+require 'sinatra/base'
+require 'sidekiq/api'
+
+module Pliny::Sidekiq
+  module Endpoints
+    class Health < Sinatra::Base
+      get '/health/sidekiq' do
+        log_health
+        MultiJson.encode(health)
+      end
+
+      private
+
+      def health
+        {
+          latency: latency,
+          depth:   depth
+        }
+      end
+
+      def queue
+        @queue ||= ::Sidekiq::Queue.new
+      end
+
+      def latency
+        queue.latency
+      end
+
+      def depth
+        queue.size
+      end
+
+      def log_prefix
+        "measure#sidekiq."
+      end
+
+      def log_health
+        data = {
+          sidekiq: true,
+          health:  true
+        }.merge(Hash[health.map { |k, v| ["#{log_prefix}#{k}", v] }])
+
+        Pliny.log(data)
+      end
+    end
+  end
+end

--- a/pliny-sidekiq.gemspec
+++ b/pliny-sidekiq.gemspec
@@ -24,5 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rack-test"
   spec.add_development_dependency "rspec", "~> 3.3"
 end

--- a/spec/endpoints/health_spec.rb
+++ b/spec/endpoints/health_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+
+describe Pliny::Sidekiq::Endpoints::Health do
+  include Rack::Test::Methods
+
+  def app
+    described_class
+  end
+
+  describe 'GET /health/sidekiq' do
+    before do
+      Sidekiq::Worker.clear_all
+    end
+
+    it 'reports zero on empty queues' do
+      get '/health/sidekiq'
+      expect(last_response.status).to eq(200)
+      response = MultiJson.decode(last_response.body)
+      expect(response['latency']).to be 0
+      expect(response['depth']).to be 0
+    end
+  end
+end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,11 +6,17 @@ Bundler.require
 
 require "pliny"
 require "sidekiq"
+require "sidekiq/testing"
+require "rack/test"
 # require "timecop"
 
 require_relative "../lib/pliny/sidekiq"
 
+Sidekiq::Testing.fake!
+
 RSpec.configure do |config|
+  config.include Rack::Test::Methods
+
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 


### PR DESCRIPTION
Adds a `GET /health/sidekiq` endpoint which contains the default queue depth and latency. Also logs measurements with those values.
