### PR TITLE
Use Pliny's Metrics API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Pliny `0.18.0` or greater is now required.
-- Metrics reporting for job queue counts now use the `Pliny::Metrics` API.
+- Metrics reporting for job and queue counts now use the `Pliny::Metrics` API.
 
 ### Removed
 - the `metrics-prefix` option is no longer supported for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+### Added
+
+### Changed
+- Pliny `0.18.0` or greater is now required.
+- Metrics reporting for job queue counts now use the `Pliny::Metrics` API.
+
+### Removed
+- the `metrics-prefix` option is no longer supported for
+  `Pliny::Sidekiq::Middleware::Server::Log`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,5 +12,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Metrics reporting for job and queue counts now use the `Pliny::Metrics` API.
 
 ### Removed
-- the `metrics-prefix` option is no longer supported for
-  `Pliny::Sidekiq::Middleware::Server::Log`.
+- Options for `Pliny::Sidekiq::Middleware::Server::Log` are no longer
+  supported, including `metric_prefix`.

--- a/lib/pliny/sidekiq/middleware/server/log.rb
+++ b/lib/pliny/sidekiq/middleware/server/log.rb
@@ -1,9 +1,6 @@
 module Pliny::Sidekiq::Middleware
   module Server
     class Log
-      def initialize(opts={})
-      end
-
       def call(worker, job, queue)
         context = {
           sidekiq: true,

--- a/lib/pliny/sidekiq/middleware/server/log.rb
+++ b/lib/pliny/sidekiq/middleware/server/log.rb
@@ -1,8 +1,7 @@
 module Pliny::Sidekiq::Middleware
   module Server
     class Log
-      def initialize(metric_prefix: nil)
-        @metric_prefix = metric_prefix
+      def initialize(opts={})
       end
 
       def call(worker, job, queue)
@@ -25,11 +24,7 @@ module Pliny::Sidekiq::Middleware
       private
 
       def count(key, value=1)
-        Pliny.log("count##{metric_prefix}sidekiq.#{key}" => value)
-      end
-
-      def metric_prefix
-        @metric_prefix.nil? ? '' : "#{@metric_prefix}."
+        Pliny::Metrics.count("sidekiq.#{key}", value)
       end
     end
   end

--- a/lib/pliny/sidekiq/version.rb
+++ b/lib/pliny/sidekiq/version.rb
@@ -1,5 +1,5 @@
 module Pliny
   module Sidekiq
-    VERSION = "0.1.2"
+    VERSION = "0.2.0"
   end
 end

--- a/pliny-sidekiq.gemspec
+++ b/pliny-sidekiq.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "pliny"
+  spec.add_dependency "pliny", ">= 0.18.0"
   spec.add_dependency "sidekiq"
 
   spec.add_development_dependency "bundler", "~> 1.10"

--- a/spec/sidekiq/middleware/server/log_spec.rb
+++ b/spec/sidekiq/middleware/server/log_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Pliny::Sidekiq::Middleware::Server::Log do
-  let(:middleware) { described_class.new(options) }
+  let(:middleware) { described_class.new }
 
   let(:jid)        { SecureRandom.uuid }
   let(:class_name) { 'Class' }

--- a/spec/sidekiq/middleware/server/log_spec.rb
+++ b/spec/sidekiq/middleware/server/log_spec.rb
@@ -16,6 +16,7 @@ describe Pliny::Sidekiq::Middleware::Server::Log do
   subject(:call_middleware) { middleware.call(worker, job, queue) { } }
 
   it 'yields' do
+    allow(Pliny::Metrics).to receive(:count)
     expect { |b| middleware.call(worker, job, queue, &b) }.to yield_with_no_args
   end
 
@@ -39,11 +40,11 @@ describe Pliny::Sidekiq::Middleware::Server::Log do
     call_middleware
   end
 
-  it 'counts with no metric_prefix' do
-    allow(Pliny).to receive(:log)
+  it 'counts worker metrics' do
+    allow(Pliny::Metrics).to receive(:count)
 
-    expect(Pliny).to receive(:log)
-      .with(hash_including("count#sidekiq.worker.#{class_name}" => 1))
+    expect(Pliny::Metrics).to receive(:count)
+      .with("sidekiq.worker.#{class_name}", 1)
       .once
 
     call_middleware
@@ -57,20 +58,6 @@ describe Pliny::Sidekiq::Middleware::Server::Log do
       .once
 
     call_middleware
-  end
-
-  context "with a metric_prefix" do
-    let(:options) { { metric_prefix: 'my-app' } }
-
-    it 'counts with the metric_prefix' do
-      allow(Pliny).to receive(:log)
-
-      expect(Pliny).to receive(:log)
-        .with(hash_including("count#my-app.sidekiq.worker.#{class_name}" => 1))
-        .once
-
-      call_middleware
-    end
   end
 end
 


### PR DESCRIPTION
Currently, the sidekiq logger sends metrics to `Pliny.log` in the l2met style. Now that Pliny has it's own Metrics module with pluggable backends, it makes sense to reuse the user's configuration there. 

Checklist:
- [x] Update to a pliny version with Pliny::Metrics
- [x] Use Pliny::Metrics to track job and queue counts
- [x] Remove the `metric_prefix` option and initializer (this is already handled in `Pliny::Metrics`)
- [x] Update changelog
- [x] Bump minor version