### PR TITLE
Fix argument error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- A bug that prevented counts from being tracked
+
 ## 0.2.1
 
 ### Fixed

--- a/lib/pliny/sidekiq/middleware/server/log.rb
+++ b/lib/pliny/sidekiq/middleware/server/log.rb
@@ -24,7 +24,7 @@ module Pliny::Sidekiq::Middleware
       private
 
       def count(key, value=1)
-        Pliny::Metrics.count("sidekiq.#{key}", value)
+        Pliny::Metrics.count("sidekiq.#{key}", value: value)
       end
     end
   end

--- a/spec/sidekiq/middleware/server/log_spec.rb
+++ b/spec/sidekiq/middleware/server/log_spec.rb
@@ -44,7 +44,7 @@ describe Pliny::Sidekiq::Middleware::Server::Log do
     allow(Pliny::Metrics).to receive(:count)
 
     expect(Pliny::Metrics).to receive(:count)
-      .with("sidekiq.worker.#{class_name}", 1)
+      .with("sidekiq.worker.#{class_name}", value: 1)
       .once
 
     call_middleware


### PR DESCRIPTION
`Pliny::Metrics.count` expects a hash as the final argument.