### PR TITLE
add Pliny::Sidekiq::JobLogger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/)
+The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+  Pliny::Sidekiq::JobLogger to use as Sidekiq job logger `config.options[:job_logger]`
 
 ## 0.2.2
 

--- a/lib/pliny/sidekiq.rb
+++ b/lib/pliny/sidekiq.rb
@@ -1,4 +1,5 @@
 require "pliny/sidekiq/version"
+require "pliny/sidekiq/job_logger"
 require "pliny/sidekiq/middleware/client/log"
 require "pliny/sidekiq/middleware/client/request_id"
 require "pliny/sidekiq/middleware/server/log"

--- a/lib/pliny/sidekiq/job_logger.rb
+++ b/lib/pliny/sidekiq/job_logger.rb
@@ -1,0 +1,32 @@
+module Pliny::Sidekiq
+  class JobLogger
+    def call(job, queue)
+      context = {
+        sidekiq: true,
+        job:     job['class'],
+        job_jid:  job['jid'],
+        job_retry: job['retry'],
+      }
+
+      begin
+        start = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+        log(context, job_logger: true, at: :start)
+        yield
+        log(context, job_logger: true, at: :finish, status: :done, duration: elapsed(start))
+      rescue Exception
+        log(context, job_logger: true, at: :finish, status: :fail, duration: elapsed(start))
+        raise
+      end
+    end
+
+    private
+
+    def log(context, data = {}, &blk)
+      Pliny.log(context.merge(data), &blk)
+    end
+
+    def elapsed(start)
+      (::Process.clock_gettime(::Process::CLOCK_MONOTONIC) - start).round(3)
+    end
+  end
+end

--- a/spec/sidekiq/job_logger_spec.rb
+++ b/spec/sidekiq/job_logger_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe Pliny::Sidekiq::JobLogger do
+  let(:job_logger) { described_class.new }
+
+  let(:jid)        { SecureRandom.uuid }
+  let(:class_name) { 'TestClass' }
+  let(:job_retry)  { 1 }
+
+  let(:job)        { { 'jid' => jid, 'class' => class_name, 'retry' => job_retry } }
+  let(:queue)      { 'queue:default' }
+
+  it 'yields' do
+    expect { |b| job_logger.call(job, queue, &b) }.to yield_with_no_args
+  end
+
+  it 'logs the job start and finish' do
+    expect(Pliny).to receive(:log)
+      .with(
+        hash_including(
+          sidekiq: true,
+          job: class_name,
+          job_jid: jid,
+          job_retry: job_retry,
+          job_logger: true,
+          at: :start
+        )
+      )
+      .once
+
+    expect(Pliny).to receive(:log)
+      .with(
+        hash_including(
+          sidekiq: true,
+          job: class_name,
+          job_jid: jid,
+          job_retry: job_retry,
+          job_logger: true,
+          at: :finish,
+          status: :done,
+        )
+      )
+      .once
+
+    job_logger.call(job, queue) { }
+  end
+end
+


### PR DESCRIPTION
add JobLogger, this will allow us to configure Sidekiq to use this job logger. 

```ruby
Sidekiq.configure_server do |config|
  config.options[:job_logger] = Pliny::Sidekiq::JobLogger
end
```

This simplifies the tracking of failed/successful job

the first line for each job will look like this:

```
job_jid=03032bbe4202a223f9933581 job_retry=0 job_logger at=start
```

instead of
```
JID-03032bbe4202a223f9933581 INFO: start
```

the last line for each job will look like
```
job_id=03032bbe4202a223f9933581 job_retry=0 job_logger at=finish status=done duration=0.006
```

instead of 

```
JID-03032bbe4202a223f9933581 INFO: done: 0.007 sec

```