### PR TITLE
Pin `pliny-sidekiq` to <= `sidekiq` `6.0.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.3.2]
+### Fixed
+- Pin to sidekiq <= 6.0.1  to avoid breaking change in `Pliny::Sidekiq::JobLogger`
+
 ## [0.3.1]
 ### Fixed
 - rename job_jid to job_id in logs

--- a/lib/pliny/sidekiq/version.rb
+++ b/lib/pliny/sidekiq/version.rb
@@ -1,5 +1,5 @@
 module Pliny
   module Sidekiq
-    VERSION = "0.3.1"
+    VERSION = "0.3.2"
   end
 end

--- a/pliny-sidekiq.gemspec
+++ b/pliny-sidekiq.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "pliny", ">= 0.18.0"
-  spec.add_dependency "sidekiq"
+  spec.add_dependency "sidekiq", "<= 6.0.0"
 
   spec.add_development_dependency "pry"
   spec.add_development_dependency "pry-byebug"


### PR DESCRIPTION
Newer versions of sidekiq have changed the API used by `Pliny::Sidekiq::JobLogger`.

Future PR will update to newer API - this version will remain for apps that can't upgrade sidekiq at the moment and allow the valid version selection to resolve correctly.