### PR TITLE
Update `Pliny::Sidekiq::JobLogger` to new sidekiq API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,4 @@ language: ruby
 rvm:
   - 2.6.3
   - 2.5.5
-  - 2.4.6
 before_install: gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 3.0.2
   - 2.7.4
   - 2.6.8
 before_install: gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
-  - 2.6.3
-  - 2.5.5
+  - 3.0.2
+  - 2.7.4
+  - 2.6.8
 before_install: gem install bundler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.3.3]
+### Fixed
+- Updated `Pliny::Sidekiq::JobLogger` to be compatible with newer sidekiq versions
+
 ## [0.3.2]
 ### Fixed
 - Pin to sidekiq <= 6.0.1  to avoid breaking change in `Pliny::Sidekiq::JobLogger`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.3.3]
+## [0.4.0]
 ### Fixed
 - Updated `Pliny::Sidekiq::JobLogger` to be compatible with newer sidekiq versions
 

--- a/lib/pliny/sidekiq/job_logger.rb
+++ b/lib/pliny/sidekiq/job_logger.rb
@@ -1,5 +1,9 @@
 module Pliny::Sidekiq
   class JobLogger
+    def prepare(job)
+      yield
+    end
+
     def call(job, queue)
       context = {
         sidekiq: true,

--- a/lib/pliny/sidekiq/job_logger.rb
+++ b/lib/pliny/sidekiq/job_logger.rb
@@ -1,7 +1,9 @@
 module Pliny::Sidekiq
   class JobLogger
+
+    # As of Sidekiq `6.0.1`, `prepare` is part of the logger API. We just need to call the block defined in Sidekiq itself.
     def prepare(job)
-      yield
+      yield job
     end
 
     def call(job, queue)

--- a/lib/pliny/sidekiq/version.rb
+++ b/lib/pliny/sidekiq/version.rb
@@ -1,5 +1,5 @@
 module Pliny
   module Sidekiq
-    VERSION = "0.3.2"
+    VERSION = "0.3.3"
   end
 end

--- a/lib/pliny/sidekiq/version.rb
+++ b/lib/pliny/sidekiq/version.rb
@@ -1,5 +1,5 @@
 module Pliny
   module Sidekiq
-    VERSION = "0.3.3"
+    VERSION = "0.4.0"
   end
 end

--- a/pliny-sidekiq.gemspec
+++ b/pliny-sidekiq.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "pliny", ">= 0.18.0"
-  spec.add_dependency "sidekiq", "<= 6.0.0"
+  spec.add_dependency "sidekiq", ">= 6.0.1", "< 7.0.0"
 
   spec.add_development_dependency "pry"
   spec.add_development_dependency "pry-byebug"

--- a/pliny-sidekiq.gemspec
+++ b/pliny-sidekiq.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "pliny", ">= 0.18.0"
-  spec.add_dependency "sidekiq", ">= 6.0.1", "< 7.0.0"
+  spec.add_dependency "sidekiq", "<= 7.0.0"
 
   spec.add_development_dependency "pry"
   spec.add_development_dependency "pry-byebug"

--- a/spec/sidekiq/job_logger_spec.rb
+++ b/spec/sidekiq/job_logger_spec.rb
@@ -11,7 +11,7 @@ describe Pliny::Sidekiq::JobLogger do
   let(:queue)      { 'queue:default' }
 
   it 'prepare yields' do
-    expect { |b| job_logger.prepare(job, &b) }.to yield_with_no_args
+    expect { |b| job_logger.prepare(job, &b) }.to yield_with_args job
   end
 
   it 'call yields' do

--- a/spec/sidekiq/job_logger_spec.rb
+++ b/spec/sidekiq/job_logger_spec.rb
@@ -10,7 +10,11 @@ describe Pliny::Sidekiq::JobLogger do
   let(:job)        { { 'jid' => jid, 'class' => class_name, 'retry' => job_retry } }
   let(:queue)      { 'queue:default' }
 
-  it 'yields' do
+  it 'prepare yields' do
+    expect { |b| job_logger.prepare(job, &b) }.to yield_with_no_args
+  end
+
+  it 'call yields' do
     expect { |b| job_logger.call(job, queue, &b) }.to yield_with_no_args
   end
 


### PR DESCRIPTION
- `.prepare` is required for `job_logger`s
- Remove ruby 2.4.6 because newer versions of sidekiq require newer ruby